### PR TITLE
fix: bad mutex access in SuspendSession 

### DIFF
--- a/session_manager.go
+++ b/session_manager.go
@@ -177,20 +177,22 @@ func (sm *SessionManager) CreateSession(sessionID, clientID string, timeout time
 // SuspendSession suspends an active session
 func (sm *SessionManager) SuspendSession(sessionID string, clientID string) error {
 	sm.sessionsMu.Lock()
-	defer sm.sessionsMu.Unlock()
 
 	session, exists := sm.sessions[sessionID]
 	if !exists {
+		sm.sessionsMu.Unlock()
 		return NewSessionNotFoundError(sessionID)
 	}
 
 	// Verify client owns this session
 	if session.ClientID != clientID {
+		sm.sessionsMu.Unlock()
 		return NewUnauthorizedError(sessionID)
 	}
 
 	// Only suspend active sessions
 	if session.State != BridgeSessionStateActive {
+		sm.sessionsMu.Unlock()
 		return NewInvalidStateError(sessionID)
 	}
 
@@ -202,6 +204,7 @@ func (sm *SessionManager) SuspendSession(sessionID string, clientID string) erro
 	session.LastSuspended = time.Now()
 	session.Connection = nil
 	sm.sessions[sessionID] = session
+	sm.sessionsMu.Unlock()
 
 	// Call hooks after updating state
 	if sm.bridge.hooks != nil {

--- a/session_manager_test.go
+++ b/session_manager_test.go
@@ -475,3 +475,110 @@ func echoHandler(t *testing.T, conn net.Conn) {
 		}
 	}
 }
+
+// TestBridgeCloseDeadlock tests that bridge.Close() does not deadlock when
+// closing connections that may be blocked on Read(). This is a regression test
+// for the deadlock in SuspendSession where it held sessionsMu.Lock() while
+// calling conn.Close(), which then tried to acquire sessionsMu.RLock() via GetSession().
+func TestBridgeCloseDeadlock(t *testing.T) {
+	// Setup logger
+	logger, _ := zap.NewDevelopment()
+	defer logger.Sync()
+
+	rootTopic := "/test"
+
+	// Create server MQTT client
+	serverOpts := mqtt.NewClientOptions().
+		AddBroker("tcp://localhost:1883").
+		SetClientID("deadlock-test-server")
+
+	serverClient := mqtt.NewClient(serverOpts)
+	if token := serverClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect server to MQTT: %v", token.Error())
+	}
+	defer serverClient.Disconnect(250)
+
+	// Create client MQTT client
+	clientOpts := mqtt.NewClientOptions().
+		AddBroker("tcp://localhost:1883").
+		SetClientID("deadlock-test-client")
+
+	clientClient := mqtt.NewClient(clientOpts)
+	if token := clientClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect client to MQTT: %v", token.Error())
+	}
+	defer clientClient.Disconnect(250)
+
+	// Create server bridge
+	serverBridge := NewMQTTNetBridge(serverClient, "deadlock-test-server",
+		WithRootTopic(rootTopic),
+		WithLogger(logger),
+		WithQoS(1),
+	)
+
+	// Create client bridge
+	clientBridge := NewMQTTNetBridge(clientClient, "deadlock-test-client",
+		WithRootTopic(rootTopic),
+		WithLogger(logger),
+		WithQoS(1),
+	)
+
+	// Small delay to ensure subscriptions are established
+	time.Sleep(100 * time.Millisecond)
+
+	// Start server goroutine to accept connections
+	serverConnChan := make(chan net.Conn, 1)
+	go func() {
+		conn, err := serverBridge.Accept()
+		if err != nil {
+			return
+		}
+		serverConnChan <- conn
+		// Block on Read() to simulate a gRPC server waiting for data
+		// This will cause conn.Close() to potentially call GetSession()
+		buf := make([]byte, 1024)
+		conn.Read(buf)
+	}()
+
+	// Establish connection from client
+	ctx := context.Background()
+	clientConn, err := clientBridge.Dial(ctx, "deadlock-test-server")
+	assert.NoError(t, err)
+
+	// Wait for server to accept the connection
+	var serverConn net.Conn
+	select {
+	case serverConn = <-serverConnChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for server to accept connection")
+	}
+
+	// Verify session exists and is active
+	sessionID := clientConn.(*MQTTNetBridgeConn).sessionID
+	session, exists := serverBridge.sessionManager.GetSession(sessionID)
+	assert.True(t, exists)
+	assert.Equal(t, BridgeSessionStateActive, session.State)
+
+	// Close the bridge with a timeout to detect deadlocks
+	// Before the fix, this would deadlock indefinitely
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- serverBridge.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("bridge.Close() deadlocked - did not complete within 2 seconds")
+	}
+
+	// Cleanup
+	clientBridge.Close()
+	if serverConn != nil {
+		err := serverConn.Close()
+		assert.NoError(t, err)
+	}
+	err = clientConn.Close()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
fix: add mutex unlock before RLock() it called, removed defer Unlock().

chore: add test for blocking conn.Close() behaviour