### PR TITLE
Fix/blocking connection close issue

### DIFF
--- a/bridge_net.go
+++ b/bridge_net.go
@@ -302,15 +302,13 @@ type MQTTNetBridgeConn struct {
 	sessionID  string
 
 	// Read buffer management
-	readBuf    chan []byte
-	readBuffer []byte // Holds partially read data
-	readMu     sync.Mutex
-	readErr    error
-	deadline   time.Time
+	readBuf      chan []byte
+	readMu       sync.Mutex
+	deadline     time.Time
+	readBufClose sync.Once // Protects against double-close of readBuf
 
 	// Write management
 	writeMu   sync.Mutex
-	writeErr  error
 	wDeadline time.Time
 
 	// Connection state
@@ -329,9 +327,6 @@ type MQTTNetBridgeConn struct {
 		payload []byte
 		topic   string
 	}
-
-	reader io.Reader
-	writer io.Writer
 }
 
 func (c *MQTTNetBridgeConn) SessionID() string {
@@ -371,6 +366,8 @@ func (c *MQTTNetBridgeConn) Read(b []byte) (n int, err error) {
 		return n, nil
 	case <-timeout:
 		return 0, os.ErrDeadlineExceeded
+	case <-c.ctx.Done():
+		return 0, net.ErrClosed
 	case <-c.bridge.ctx.Done():
 		return 0, c.bridge.ctx.Err()
 	}
@@ -380,8 +377,19 @@ func (c *MQTTNetBridgeConn) Write(b []byte) (n int, err error) {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 
-	if c.closed {
-		return 0, fmt.Errorf("connection closed")
+	// Check context before proceeding (unblocks immediately if Close() was called)
+	select {
+	case <-c.ctx.Done():
+		return 0, net.ErrClosed
+	default:
+	}
+
+	// Check closed flag with proper synchronization
+	c.closeMu.RLock()
+	closed := c.closed
+	c.closeMu.RUnlock()
+	if closed {
+		return 0, net.ErrClosed
 	}
 
 	// Determine which topic to use based on role
@@ -396,14 +404,50 @@ func (c *MQTTNetBridgeConn) Write(b []byte) (n int, err error) {
 		zap.Int("bytes", len(b)),
 		zap.String("topic", topic))
 
-	if !token.WaitTimeout(5 * time.Second) {
-		return 0, fmt.Errorf("write timeout")
-	}
-	if token.Error() != nil {
-		return 0, token.Error()
-	}
+	// Wait for publish with timeout, but check context periodically
+	done := make(chan struct{})
+	var publishErr error
+	go func() {
+		if !token.WaitTimeout(5 * time.Second) {
+			publishErr = fmt.Errorf("write timeout")
+		} else if token.Error() != nil {
+			publishErr = token.Error()
+		}
+		close(done)
+	}()
 
-	return len(b), nil
+	// Wait for publish to complete, but also check for closure
+	select {
+	case <-c.ctx.Done():
+		return 0, net.ErrClosed
+	case <-done:
+		// Publish completed, but check if connection was closed
+		// This check must happen AFTER publish completes but BEFORE we return
+		c.closeMu.RLock()
+		closed := c.closed
+		c.closeMu.RUnlock()
+		if closed {
+			return 0, net.ErrClosed
+		}
+		// Also check context one more time as a final check
+		select {
+		case <-c.ctx.Done():
+			return 0, net.ErrClosed
+		default:
+			// Context not cancelled, but check closed flag one more time
+			// to handle race condition where Close() is called between checks
+			c.closeMu.RLock()
+			if c.closed {
+				c.closeMu.RUnlock()
+				return 0, net.ErrClosed
+			}
+			c.closeMu.RUnlock()
+		}
+		if publishErr != nil {
+			return 0, publishErr
+		}
+		return len(b), nil
+	}
 }
 
 func (c *MQTTNetBridgeConn) Close() error {
@@ -415,8 +459,15 @@ func (c *MQTTNetBridgeConn) Close() error {
 	c.closed = true
 	c.closeMu.Unlock()
 
-	// Only call DisconnectSession if we're not already being closed by it
-	// and if the session is still active
+	// FIRST: Cancel context to unblock any waiting Read/Write operations
+	c.cancel()
+
+	// SECOND: Close readBuf to signal EOF to readers (idempotent via sync.Once)
+	c.readBufClose.Do(func() {
+		close(c.readBuf)
+	})
+
+	// THEN: Handle session cleanup (non-blocking path)
 	select {
 	case <-c.ctx.Done():
 		// Context already cancelled, we're being closed by DisconnectSession
@@ -434,7 +485,6 @@ func (c *MQTTNetBridgeConn) Close() error {
 		}
 	}
 
-	c.cancel()
 	return nil
 }
 

--- a/bridge_net_test.go
+++ b/bridge_net_test.go
@@ -720,7 +720,7 @@ func TestCloseUnblocksWrite(t *testing.T) {
 	writeErr := make(chan error, 1)
 	go func() {
 		defer close(writeDone)
-		largeData := make([]byte, 1024*1024) // 1MB to potentially cause blocking
+		largeData := make([]byte, 10*1024*1024) // 10MB to potentially cause blocking
 		_, err := clientConn.Write(largeData)
 		writeErr <- err
 	}()

--- a/bridge_net_test.go
+++ b/bridge_net_test.go
@@ -307,7 +307,7 @@ func TestMQTTBridgeProxy(t *testing.T) {
 	defer logger.Sync()
 
 	// Create a temporary Unix socket path with unique name
-	sockPath := fmt.Sprintf("/tmp/test-proxy.sock")
+	sockPath := "/tmp/test-proxy.sock"
 
 	if err := os.Remove(sockPath); err != nil && !os.IsNotExist(err) {
 		logger.Error("Failed to clean up existing socket", zap.String("address", sockPath), zap.Error(err))
@@ -516,4 +516,347 @@ func TestMQTTBridgeProxy(t *testing.T) {
 	default:
 		// No errors, test passed
 	}
+}
+
+// TestCloseUnblocksRead verifies that a blocked Read() operation unblocks immediately
+// when Close() is called, as required by the net.Conn interface contract.
+func TestCloseUnblocksRead(t *testing.T) {
+	// Setup logger
+	logger, _ := zap.NewDevelopment()
+	defer logger.Sync()
+
+	// Create MQTT clients
+	serverClient := mqtt.NewClient(mqtt.NewClientOptions().
+		AddBroker("tcp://localhost:1883").
+		SetClientID("bridge-test-close-read-server"))
+
+	if token := serverClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect server to MQTT: %v", token.Error())
+	}
+	defer serverClient.Disconnect(250)
+
+	// Create bridge listener
+	serverBridgeID := "test-close-read-server"
+	rootTopic := "/vedant/close-read"
+	listener := NewMQTTNetBridge(serverClient, serverBridgeID,
+		WithRootTopic(rootTopic),
+		WithLogger(logger),
+		WithQoS(2),
+	)
+	defer listener.Close()
+
+	// Create client MQTT client
+	clientClient := mqtt.NewClient(mqtt.NewClientOptions().
+		AddBroker("tcp://localhost:1883").
+		SetClientID("bridge-test-close-read-client"))
+
+	if token := clientClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect client to MQTT: %v", token.Error())
+	}
+	defer clientClient.Disconnect(250)
+
+	// Create client bridge
+	clientBridgeID := "test-close-read-client"
+	clientBridge := NewMQTTNetBridge(clientClient, clientBridgeID,
+		WithRootTopic(rootTopic),
+		WithLogger(logger))
+	defer clientBridge.Close()
+
+	// Start server goroutine
+	serverConn := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Errorf("Accept error: %v", err)
+			return
+		}
+		serverConn <- conn
+	}()
+
+	// Connect client to server
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clientConn, err := clientBridge.Dial(ctx, serverBridgeID)
+	if err != nil {
+		t.Fatalf("Failed to connect to server: %v", err)
+	}
+
+	// Wait for server connection
+	var conn net.Conn
+	select {
+	case conn = <-serverConn:
+		t.Log("Server accepted connection")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for server connection")
+	}
+	defer conn.Close()
+
+	// Allow time for subscriptions to be established
+	time.Sleep(500 * time.Millisecond)
+
+	// Start a goroutine that blocks on Read()
+	readDone := make(chan struct{})
+	readErr := make(chan error, 1)
+	go func() {
+		defer close(readDone)
+		buf := make([]byte, 1024)
+		_, err := clientConn.Read(buf)
+		readErr <- err
+	}()
+
+	// Give Read() a moment to block
+	time.Sleep(100 * time.Millisecond)
+
+	// Close the connection - this should unblock the Read()
+	closeStart := time.Now()
+	err = clientConn.Close()
+	assert.NoError(t, err)
+
+	// Wait for Read() to unblock (should happen immediately)
+	select {
+	case err := <-readErr:
+		closeDuration := time.Since(closeStart)
+		// Read should have unblocked within 500ms (much faster than any timeout)
+		assert.Less(t, closeDuration, 500*time.Millisecond,
+			"Read() should unblock immediately after Close()")
+		// Should return net.ErrClosed or io.EOF
+		assert.True(t, err == net.ErrClosed || err == io.EOF,
+			"Read() should return net.ErrClosed or io.EOF, got: %v", err)
+		t.Logf("Read() unblocked after %v with error: %v", closeDuration, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read() did not unblock within 2 seconds after Close()")
+	}
+
+	// Wait for goroutine to finish
+	select {
+	case <-readDone:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Error("Read goroutine did not finish")
+	}
+}
+
+// TestCloseUnblocksWrite verifies that a blocked Write() operation unblocks immediately
+// when Close() is called, as required by the net.Conn interface contract.
+func TestCloseUnblocksWrite(t *testing.T) {
+	// Setup logger
+	logger, _ := zap.NewDevelopment()
+	defer logger.Sync()
+
+	// Create MQTT clients
+	serverClient := mqtt.NewClient(mqtt.NewClientOptions().
+		AddBroker("tcp://localhost:1883").
+		SetClientID("bridge-test-close-write-server"))
+
+	if token := serverClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect server to MQTT: %v", token.Error())
+	}
+	defer serverClient.Disconnect(250)
+
+	// Create bridge listener
+	serverBridgeID := "test-close-write-server"
+	rootTopic := "/vedant/close-write"
+	listener := NewMQTTNetBridge(serverClient, serverBridgeID,
+		WithRootTopic(rootTopic),
+		WithLogger(logger),
+		WithQoS(2),
+	)
+	defer listener.Close()
+
+	// Create client MQTT client
+	clientClient := mqtt.NewClient(mqtt.NewClientOptions().
+		AddBroker("tcp://localhost:1883").
+		SetClientID("bridge-test-close-write-client"))
+
+	if token := clientClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect client to MQTT: %v", token.Error())
+	}
+	defer clientClient.Disconnect(250)
+
+	// Create client bridge
+	clientBridgeID := "test-close-write-client"
+	clientBridge := NewMQTTNetBridge(clientClient, clientBridgeID,
+		WithRootTopic(rootTopic),
+		WithLogger(logger))
+	defer clientBridge.Close()
+
+	// Start server goroutine
+	serverConn := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Errorf("Accept error: %v", err)
+			return
+		}
+		serverConn <- conn
+	}()
+
+	// Connect client to server
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clientConn, err := clientBridge.Dial(ctx, serverBridgeID)
+	if err != nil {
+		t.Fatalf("Failed to connect to server: %v", err)
+	}
+
+	// Wait for server connection
+	var conn net.Conn
+	select {
+	case conn = <-serverConn:
+		t.Log("Server accepted connection")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for server connection")
+	}
+	defer conn.Close()
+
+	// Allow time for subscriptions to be established
+	time.Sleep(500 * time.Millisecond)
+
+	// Start a goroutine that blocks on Write()
+	// We'll write a large message to potentially block
+	writeDone := make(chan struct{})
+	writeErr := make(chan error, 1)
+	go func() {
+		defer close(writeDone)
+		largeData := make([]byte, 1024*1024) // 1MB to potentially cause blocking
+		_, err := clientConn.Write(largeData)
+		writeErr <- err
+	}()
+
+	// Give Write() a moment to potentially block
+	time.Sleep(100 * time.Millisecond)
+
+	// Close the connection - this should unblock the Write()
+	closeStart := time.Now()
+	err = clientConn.Close()
+	assert.NoError(t, err)
+
+	// Wait for Write() to unblock (should happen immediately)
+	select {
+	case err := <-writeErr:
+		closeDuration := time.Since(closeStart)
+		// Write should have unblocked within 500ms (much faster than any timeout)
+		assert.Less(t, closeDuration, 500*time.Millisecond,
+			"Write() should unblock immediately after Close()")
+		// Should return net.ErrClosed
+		assert.Equal(t, net.ErrClosed, err,
+			"Write() should return net.ErrClosed, got: %v", err)
+		t.Logf("Write() unblocked after %v with error: %v", closeDuration, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Write() did not unblock within 2 seconds after Close()")
+	}
+
+	// Wait for goroutine to finish
+	select {
+	case <-writeDone:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Error("Write goroutine did not finish")
+	}
+}
+
+// TestCloseIdempotent verifies that multiple calls to Close() are safe and idempotent.
+func TestCloseIdempotent(t *testing.T) {
+	// Setup logger
+	logger, _ := zap.NewDevelopment()
+	defer logger.Sync()
+
+	// Create MQTT clients
+	serverClient := mqtt.NewClient(mqtt.NewClientOptions().
+		AddBroker("tcp://localhost:1883").
+		SetClientID("bridge-test-close-idempotent-server"))
+
+	if token := serverClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect server to MQTT: %v", token.Error())
+	}
+	defer serverClient.Disconnect(250)
+
+	// Create bridge listener
+	serverBridgeID := "test-close-idempotent-server"
+	rootTopic := "/vedant/close-idempotent"
+	listener := NewMQTTNetBridge(serverClient, serverBridgeID,
+		WithRootTopic(rootTopic),
+		WithLogger(logger),
+		WithQoS(2),
+	)
+	defer listener.Close()
+
+	// Create client MQTT client
+	clientClient := mqtt.NewClient(mqtt.NewClientOptions().
+		AddBroker("tcp://localhost:1883").
+		SetClientID("bridge-test-close-idempotent-client"))
+
+	if token := clientClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect client to MQTT: %v", token.Error())
+	}
+	defer clientClient.Disconnect(250)
+
+	// Create client bridge
+	clientBridgeID := "test-close-idempotent-client"
+	clientBridge := NewMQTTNetBridge(clientClient, clientBridgeID,
+		WithRootTopic(rootTopic),
+		WithLogger(logger))
+	defer clientBridge.Close()
+
+	// Start server goroutine
+	serverConn := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		serverConn <- conn
+	}()
+
+	// Connect client to server
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clientConn, err := clientBridge.Dial(ctx, serverBridgeID)
+	if err != nil {
+		t.Fatalf("Failed to connect to server: %v", err)
+	}
+
+	// Wait for server connection
+	select {
+	case <-serverConn:
+		t.Log("Server accepted connection")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for server connection")
+	}
+
+	// Allow time for subscriptions to be established
+	time.Sleep(500 * time.Millisecond)
+
+	// Call Close() multiple times concurrently
+	closeCount := 10
+	closeErrs := make(chan error, closeCount)
+	for i := 0; i < closeCount; i++ {
+		go func() {
+			closeErrs <- clientConn.Close()
+		}()
+	}
+
+	// Collect all results
+	var errors []error
+	for i := 0; i < closeCount; i++ {
+		select {
+		case err := <-closeErrs:
+			errors = append(errors, err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("Close() did not return within 2 seconds")
+		}
+	}
+
+	// All Close() calls should succeed (return nil)
+	for i, err := range errors {
+		assert.NoError(t, err, "Close() call %d should succeed", i+1)
+	}
+
+	// Verify connection is actually closed
+	_, err = clientConn.Write([]byte("test"))
+	assert.Error(t, err, "Write should fail after Close()")
+	assert.Equal(t, net.ErrClosed, err, "Write should return net.ErrClosed")
 }

--- a/session_manager.go
+++ b/session_manager.go
@@ -177,20 +177,22 @@ func (sm *SessionManager) CreateSession(sessionID, clientID string, timeout time
 // SuspendSession suspends an active session
 func (sm *SessionManager) SuspendSession(sessionID string, clientID string) error {
 	sm.sessionsMu.Lock()
-	defer sm.sessionsMu.Unlock()
 
 	session, exists := sm.sessions[sessionID]
 	if !exists {
+		sm.sessionsMu.Unlock()
 		return NewSessionNotFoundError(sessionID)
 	}
 
 	// Verify client owns this session
 	if session.ClientID != clientID {
+		sm.sessionsMu.Unlock()
 		return NewUnauthorizedError(sessionID)
 	}
 
 	// Only suspend active sessions
 	if session.State != BridgeSessionStateActive {
+		sm.sessionsMu.Unlock()
 		return NewInvalidStateError(sessionID)
 	}
 
@@ -202,6 +204,7 @@ func (sm *SessionManager) SuspendSession(sessionID string, clientID string) erro
 	session.LastSuspended = time.Now()
 	session.Connection = nil
 	sm.sessions[sessionID] = session
+	sm.sessionsMu.Unlock()
 
 	// Call hooks after updating state
 	if sm.bridge.hooks != nil {

--- a/session_manager.go
+++ b/session_manager.go
@@ -216,14 +216,8 @@ func (sm *SessionManager) SuspendSession(sessionID string, clientID string) erro
 
 	// Close connection after releasing lock if it exists
 	if conn != nil {
-		// Cancel context and mark as closed
-		conn.cancel()
-		conn.closeMu.Lock()
-		conn.closed = true
-		conn.closeMu.Unlock()
-
-		// Let the connection's Close() method handle channel closing
-		// This avoids the double close issue
+		// Use Close() which handles context cancellation, channel closing, and cleanup
+		// sync.Once ensures idempotency if called multiple times
 		conn.Close()
 	}
 
@@ -507,11 +501,9 @@ func (sm *SessionManager) HandleLifecycleMessage(payload []byte, topic string) {
 
 			// Close connection after releasing lock if it exists
 			if conn != nil {
-				conn.connMu.Lock()
-				conn.closed = true
-				close(conn.readBuf)
-				conn.connMu.Unlock()
-				conn.cancel()
+				// Use Close() which handles context cancellation, channel closing, and cleanup
+				// sync.Once ensures idempotency if called multiple times
+				conn.Close()
 			}
 		} else {
 			sm.sessionsMu.Unlock()

--- a/session_manager_test.go
+++ b/session_manager_test.go
@@ -475,3 +475,110 @@ func echoHandler(t *testing.T, conn net.Conn) {
 		}
 	}
 }
+
+// TestBridgeCloseDeadlock tests that bridge.Close() does not deadlock when
+// closing connections that may be blocked on Read(). This is a regression test
+// for the deadlock in SuspendSession where it held sessionsMu.Lock() while
+// calling conn.Close(), which then tried to acquire sessionsMu.RLock() via GetSession().
+func TestBridgeCloseDeadlock(t *testing.T) {
+	// Setup logger
+	logger, _ := zap.NewDevelopment()
+	defer logger.Sync()
+
+	rootTopic := "/test"
+
+	// Create server MQTT client
+	serverOpts := mqtt.NewClientOptions().
+		AddBroker("tcp://localhost:1883").
+		SetClientID("deadlock-test-server")
+
+	serverClient := mqtt.NewClient(serverOpts)
+	if token := serverClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect server to MQTT: %v", token.Error())
+	}
+	defer serverClient.Disconnect(250)
+
+	// Create client MQTT client
+	clientOpts := mqtt.NewClientOptions().
+		AddBroker("tcp://localhost:1883").
+		SetClientID("deadlock-test-client")
+
+	clientClient := mqtt.NewClient(clientOpts)
+	if token := clientClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("Failed to connect client to MQTT: %v", token.Error())
+	}
+	defer clientClient.Disconnect(250)
+
+	// Create server bridge
+	serverBridge := NewMQTTNetBridge(serverClient, "deadlock-test-server",
+		WithRootTopic(rootTopic),
+		WithLogger(logger),
+		WithQoS(1),
+	)
+
+	// Create client bridge
+	clientBridge := NewMQTTNetBridge(clientClient, "deadlock-test-client",
+		WithRootTopic(rootTopic),
+		WithLogger(logger),
+		WithQoS(1),
+	)
+
+	// Small delay to ensure subscriptions are established
+	time.Sleep(100 * time.Millisecond)
+
+	// Start server goroutine to accept connections
+	serverConnChan := make(chan net.Conn, 1)
+	go func() {
+		conn, err := serverBridge.Accept()
+		if err != nil {
+			return
+		}
+		serverConnChan <- conn
+		// Block on Read() to simulate a gRPC server waiting for data
+		// This will cause conn.Close() to potentially call GetSession()
+		buf := make([]byte, 1024)
+		conn.Read(buf)
+	}()
+
+	// Establish connection from client
+	ctx := context.Background()
+	clientConn, err := clientBridge.Dial(ctx, "deadlock-test-server")
+	assert.NoError(t, err)
+
+	// Wait for server to accept the connection
+	var serverConn net.Conn
+	select {
+	case serverConn = <-serverConnChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for server to accept connection")
+	}
+
+	// Verify session exists and is active
+	sessionID := clientConn.(*MQTTNetBridgeConn).sessionID
+	session, exists := serverBridge.sessionManager.GetSession(sessionID)
+	assert.True(t, exists)
+	assert.Equal(t, BridgeSessionStateActive, session.State)
+
+	// Close the bridge with a timeout to detect deadlocks
+	// Before the fix, this would deadlock indefinitely
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- serverBridge.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("bridge.Close() deadlocked - did not complete within 2 seconds")
+	}
+
+	// Cleanup
+	clientBridge.Close()
+	if serverConn != nil {
+		err := serverConn.Close()
+		assert.NoError(t, err)
+	}
+	err = clientConn.Close()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Made the MQTTNetBridgeConn.Close() method gurantee net.Conn.Close() semantics i.e. every blocking read/write should be unblocked when Close() is called.

All tests except TestCloseUnblocksWrite passing.
In TestCloseUnblocksWrite the mqtt publish completes in microseconds where as bridgeNetConn.Close() completes in nanoseconds therefore no blocking write is present at closing time.